### PR TITLE
Adding logic to skip video-only albums if "skipVideos" is set to true in configuration

### DIFF
--- a/main.go
+++ b/main.go
@@ -951,7 +951,7 @@ func album(albumID string, cfg *Config, streamParams *StreamParams, artResp *Alb
 
 	if skuID != 0 {
 		if cfg.SkipVideos {
-			fmt.Println("Configuration file is set to skip, so not downloading")
+			fmt.Println("Configuration is set to skip videos, so not downloading")
 			return nil
 		}
 		if cfg.ForceVideo || trackTotal < 1 {

--- a/main.go
+++ b/main.go
@@ -240,17 +240,13 @@ func parseCfg() (*Config, error) {
 	} else {
 		cfg.FfmpegNameStr = "./ffmpeg"
 	}
-	if cfg.SkipVideos {
-		cfg.SkipVideos = true
-	} else {
-		cfg.SkipVideos = args.SkipVideos
-	}
 	cfg.Urls, err = processUrls(args.Urls)
 	if err != nil {
 		fmt.Println("Failed to process URLs.")
 		return nil, err
 	}
 	cfg.ForceVideo = args.ForceVideo
+	cfg.SkipVideos = args.SkipVideos
 	return cfg, nil
 }
 

--- a/main.go
+++ b/main.go
@@ -240,13 +240,17 @@ func parseCfg() (*Config, error) {
 	} else {
 		cfg.FfmpegNameStr = "./ffmpeg"
 	}
+	if cfg.SkipVideos {
+		cfg.SkipVideos = true
+	} else {
+		cfg.SkipVideos = args.SkipVideos
+	}
 	cfg.Urls, err = processUrls(args.Urls)
 	if err != nil {
 		fmt.Println("Failed to process URLs.")
 		return nil, err
 	}
 	cfg.ForceVideo = args.ForceVideo
-	cfg.SkipVideos = args.SkipVideos
 	return cfg, nil
 }
 
@@ -946,6 +950,10 @@ func album(albumID string, cfg *Config, streamParams *StreamParams, artResp *Alb
 	}
 
 	if skuID != 0 {
+		if cfg.SkipVideos {
+			fmt.Println("Configuration file is set to skip, so not downloading")
+			return nil
+		}
 		if cfg.ForceVideo || trackTotal < 1 {
 			return video(albumID, "", cfg, streamParams, meta, false)
 		}

--- a/main.go
+++ b/main.go
@@ -947,7 +947,7 @@ func album(albumID string, cfg *Config, streamParams *StreamParams, artResp *Alb
 
 	if skuID != 0 {
 		if cfg.SkipVideos {
-			fmt.Println("Configuration is set to skip videos, so not downloading")
+			fmt.Println("Video-only album, skipped")
 			return nil
 		}
 		if cfg.ForceVideo || trackTotal < 1 {


### PR DESCRIPTION
First off, thanks so much for this amazing tool!

Onto my proposed change- I have a bash script I'm running to download, well, everything from nugs. Basically just a while loop that decrements the release ID and calls this script with an argument of `"https://play.nugs.net/release/"$RELEASE_ID`.

However, I don't want to download anything with videos, just audio.

For others who might want to do something similar, I modified two things:

1. The `config.json` accepts the `skipVideos` argument
2. If a release is a video-only release (i.e., no audio tracks), and `skipVideos` is set to `true` in either `config.json` or in the CLI arguments, the release will be skipped, and no video downloaded

I'm more than happy to write a unit test proving this works, or collaborate on a better solution to this problem, if this isn't sufficient in your eyes.

I tested locally with https://play.nugs.net/release/29001, and the video will still be downloaded as long as `skipVideos` is not set to `true`.