### PR TITLE
ffmpeg flag for chapter names

### DIFF
--- a/main.go
+++ b/main.go
@@ -1376,7 +1376,7 @@ func tsToMp4(VidPathTs, vidPath, ffmpegNameStr string, chapAvail bool) error {
 	if chapAvail {
 		args = []string{
 			"-hide_banner", "-i", VidPathTs, "-f", "ffmetadata",
-			"-i", chapsFileFname, "-map_metadata", "1", "-c", "copy", vidPath,
+			"-i", chapsFileFname, "-map_chapters", "1", "-c", "copy", vidPath,
 		}
 	} else {
 		args = []string{"-hide_banner", "-i", VidPathTs, "-c", "copy", vidPath}


### PR DESCRIPTION
Changed the ffmpeg flag from -map_metadata to -map_chapters to include chapter titles (song names) for video files.